### PR TITLE
feat: 댓글 로직 fetch 적용 및 next cache 테스트

### DIFF
--- a/app/(detail)/post/[postId]/page.tsx
+++ b/app/(detail)/post/[postId]/page.tsx
@@ -4,6 +4,8 @@ import FloatingContainer from './_components/floating-container';
 import { getLikeById, getMyLikeByPostId } from '@/app/data/like';
 import { getPostById } from '@/app/data/post';
 import { Metadata } from 'next';
+import { getCommentList } from '@/app/data/commnet';
+import { getSessionUserData } from '@/app/data/user';
 
 interface Props {
   params: { postId: string };
@@ -20,20 +22,31 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 }
 
 export default async function Page({ params }: Props) {
+  const session = await getSessionUserData();
   const post = await getPostById(params.postId);
-
-  if (!post) return <div>없는 포스트</div>;
   const { count } = await getLikeById(params.postId);
   const personalStatus = await getMyLikeByPostId({ postId: params.postId });
+  const { totalCount } = await getCommentList({
+    postId: params.postId,
+    page: 1,
+    limit: 5,
+  });
+
+  if (!post) return <div>없는 포스트</div>;
 
   return (
     <div className='flex flex-col items-center justify-center px-5 py-20 gap-10 relative w-full'>
       <PostContents
-        post={post}
+        post={post!}
         totalLike={count ? count : 0}
         personalStatus={personalStatus}
       />
-      <CommentContainer postId={params.postId} createrId={post.user_id} />
+      <CommentContainer
+        postId={params.postId}
+        createrId={post.user_id}
+        totalCount={totalCount!}
+        currentUser={session?.id}
+      />
       <FloatingContainer
         totalLike={count ? count : 0}
         createrId={post.user_id}

--- a/app/_components/nav-menu-item.tsx
+++ b/app/_components/nav-menu-item.tsx
@@ -1,4 +1,4 @@
-import { NavigationMenuLink } from '@/components/ui/navigation-menu';
+import Link from 'next/link';
 
 interface Props {
   title: string;
@@ -7,13 +7,13 @@ interface Props {
 
 export default function ListItem({ title, href }: Props) {
   return (
-    <NavigationMenuLink
+    <Link
       href={href}
       className='block select-none space-y-1 rounded-md p-3 leading-none no-underline outline-none transition-colors hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground'
     >
       <div className='font-medium leading-none text-nowrap text-center text-base'>
         {title}
       </div>
-    </NavigationMenuLink>
+    </Link>
   );
 }

--- a/utils/supabase-url-builder.ts
+++ b/utils/supabase-url-builder.ts
@@ -1,0 +1,36 @@
+import { supabaseUrl } from './supabase';
+
+interface Props {
+  table: string;
+  select: string;
+  postId: string;
+  orderBy: 'createdAt' | '';
+  orderDirection: 'desc' | '';
+  offset: number;
+  limit: number;
+}
+
+export const supabaseUrlBuilder = ({
+  table,
+  select = '*',
+  postId,
+  orderBy = 'createdAt',
+  orderDirection = 'desc',
+  offset = 0,
+  limit = 5,
+}: Props) => {
+  const url = new URL(`${supabaseUrl}/rest/v1/${table}`);
+
+  // 쿼리 파라미터 추가
+  url.searchParams.append('select', select);
+
+  if (postId) {
+    url.searchParams.append('post_id', `eq.${postId}`);
+  }
+
+  url.searchParams.append('order', `${orderBy}.${orderDirection}`);
+  url.searchParams.append('offset', String(offset));
+  url.searchParams.append('limit', String(limit));
+
+  return url.toString();
+};


### PR DESCRIPTION
댓글 데이터는 클라이언트에서 렌더링을 하도록 만들어서 매번 접속때마다 요청보냄
nextjs에서 fetch사용하면 동일한 요청에 대해서 캐싱을 지원해줘서 fetch로 변경해봄
배포시 캐싱지원되는지 확인해보겠음