### PR TITLE
댓글 mutate 적용 및 스타일 수정

### DIFF
--- a/app/(detail)/alarm/_components/alarm-card.tsx
+++ b/app/(detail)/alarm/_components/alarm-card.tsx
@@ -46,8 +46,8 @@ export default function AlarmCard({
   return (
     <Link href={link}>
       <div
-        className={`bg-white rounded-lg flex flex-col py-3 px-5 shadow hover:shadow-lg hover:-translate-y-1 transition-transform w-full ${
-          readAlarm && 'bg-gray-300'
+        className={` rounded-lg flex flex-col py-3 px-5 shadow hover:shadow-lg hover:-translate-y-1 transition-transform w-full ${
+          readAlarm ? 'bg-gray-300' : 'bg-white'
         }`}
       >
         <div className='flex gap-1'>

--- a/app/(detail)/alarm/page.tsx
+++ b/app/(detail)/alarm/page.tsx
@@ -10,13 +10,8 @@ export default async function Page() {
       <h1 className='text-2xl font-bold py-5'>알림 목록</h1>
       <div className='flex flex-col items-center justify-center gap-10 relative'>
         {data.alarms.length === 0 ? (
-          <div className='h-full'>
-            <div
-              className={`border rounded-lg flex items-center gap-2 py-3 px-5 shadow-lg hover:-translate-y-1 transition-transform 
-            }`}
-            >
-              알림 없음
-            </div>
+          <div className='flex items-center justify-center gap-5 border rounded-lg shadow-lg w-full h-28 px-8 py-4 hover:-translate-y-1 transition-transform text-2xl font-semibold'>
+            알람이 없습니다!
           </div>
         ) : (
           <ul className='flex flex-col gap-3 w-full'>

--- a/app/(detail)/post/[postId]/_components/comment-button-container.tsx
+++ b/app/(detail)/post/[postId]/_components/comment-button-container.tsx
@@ -5,6 +5,7 @@ import DeleteButton from './post-delete-button';
 import { toast } from 'sonner';
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 
 interface Props {
   commentId: string;
@@ -20,6 +21,7 @@ export default function CommentButtonContainer({
   postId,
 }: Props) {
   const [isOpen, setIsOpen] = useState(false);
+  const router = useRouter();
   const queryClient = useQueryClient();
   const mutation = useMutation({
     mutationFn: async () => {
@@ -30,6 +32,7 @@ export default function CommentButtonContainer({
       if (result.success) {
         toast.success(result.message); // 성공 메시지 표시
         queryClient.invalidateQueries({ queryKey: [`${postId}:comment`] }); // 댓글 목록 갱신
+        router.refresh();
       } else {
         toast.error(result.message); // 에러 메시지 표시
       }

--- a/app/(detail)/post/[postId]/_components/comment-button-container.tsx
+++ b/app/(detail)/post/[postId]/_components/comment-button-container.tsx
@@ -4,29 +4,40 @@ import { deleteComment } from '@/app/action/comment';
 import DeleteButton from './post-delete-button';
 import { toast } from 'sonner';
 import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 interface Props {
   commentId: string;
   toggleEdit: () => void;
   isEdit: boolean;
-  deleteList: (commentId: string) => void;
+  postId: string;
 }
 
 export default function CommentButtonContainer({
   commentId,
   toggleEdit,
   isEdit,
-  deleteList,
+  postId,
 }: Props) {
   const [isOpen, setIsOpen] = useState(false);
-  const isDeleteCommnet = async () => {
-    const result = await deleteComment(commentId);
-    setIsOpen(!isOpen);
-    if (result.success) {
-      toast.message(result.message);
-      deleteList(commentId);
-    }
-  };
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const result = await deleteComment(commentId);
+      return result;
+    },
+    onSuccess: (result) => {
+      if (result.success) {
+        toast.success(result.message); // 성공 메시지 표시
+        queryClient.invalidateQueries({ queryKey: [`${postId}:comment`] }); // 댓글 목록 갱신
+      } else {
+        toast.error(result.message); // 에러 메시지 표시
+      }
+    },
+    onError: () => {
+      toast.error('댓글 삭제에 실패했습니다.'); // 일반적인 에러 메시지 표시
+    },
+  });
 
   return (
     <div className='flex gap-2'>
@@ -36,7 +47,7 @@ export default function CommentButtonContainer({
             수정
           </div>
           <DeleteButton
-            isDelete={isDeleteCommnet}
+            isDelete={mutation.mutate}
             open={isOpen}
             setModalOpen={setIsOpen}
           />

--- a/app/(detail)/post/[postId]/_components/comment-card.tsx
+++ b/app/(detail)/post/[postId]/_components/comment-card.tsx
@@ -12,15 +12,9 @@ interface Props {
   comment: Comment;
   userId?: string;
   postId: string;
-  deleteList: (commentId: string) => void;
 }
 
-export default function CommentCard({
-  comment,
-  userId,
-  postId,
-  deleteList,
-}: Props) {
+export default function CommentCard({ comment, userId, postId }: Props) {
   const [isEdit, setIsEdit] = useState(false);
 
   const toggleEdit = () => {
@@ -41,7 +35,7 @@ export default function CommentCard({
             commentId={comment.id}
             toggleEdit={toggleEdit}
             isEdit={isEdit}
-            deleteList={deleteList}
+            postId={postId}
           />
         )}
       </div>

--- a/app/(detail)/post/[postId]/_components/comment-card.tsx
+++ b/app/(detail)/post/[postId]/_components/comment-card.tsx
@@ -12,9 +12,10 @@ interface Props {
   comment: Comment;
   userId?: string;
   postId: string;
+  page: number;
 }
 
-export default function CommentCard({ comment, userId, postId }: Props) {
+export default function CommentCard({ comment, userId, postId, page }: Props) {
   const [isEdit, setIsEdit] = useState(false);
 
   const toggleEdit = () => {
@@ -46,6 +47,7 @@ export default function CommentCard({ comment, userId, postId }: Props) {
             toggleEdit={toggleEdit}
             postId={postId}
             commentId={comment.id}
+            page={page}
           />
         ) : (
           <MarkdownEditor markdownText={comment.content} />

--- a/app/(detail)/post/[postId]/_components/comment-container.tsx
+++ b/app/(detail)/post/[postId]/_components/comment-container.tsx
@@ -3,7 +3,6 @@
 import CommentForm from './comment-form';
 import CommentCard from './comment-card';
 import { useState } from 'react';
-import { Comment } from '@/type';
 import CommentPagination from './comment-pagination';
 import { useQuery } from '@tanstack/react-query';
 import { getCommentList } from '@/app/data/commnet';

--- a/app/(detail)/post/[postId]/_components/comment-container.tsx
+++ b/app/(detail)/post/[postId]/_components/comment-container.tsx
@@ -60,6 +60,7 @@ export default function CommentContainer({
               comment={comment}
               userId={currentUser}
               postId={postId}
+              page={page}
             />
           </li>
         ))}

--- a/app/(detail)/post/[postId]/_components/comment-container.tsx
+++ b/app/(detail)/post/[postId]/_components/comment-container.tsx
@@ -40,11 +40,6 @@ export default function CommentContainer({
     setPage(1);
   };
 
-  const deleteList = (commentId: string) => {
-    const filterList = commentList.filter((item) => item.id !== commentId);
-    setCommentList(filterList);
-  };
-
   return (
     <div className='w-full max-w-[800px] gap-3 flex flex-col'>
       <div className='flex flex-col gap-2'>
@@ -63,7 +58,6 @@ export default function CommentContainer({
               comment={comment}
               userId={currentUser}
               postId={postId}
-              deleteList={deleteList}
             />
           </li>
         ))}

--- a/app/(detail)/post/[postId]/_components/comment-container.tsx
+++ b/app/(detail)/post/[postId]/_components/comment-container.tsx
@@ -8,6 +8,7 @@ import CommentPagination from './comment-pagination';
 import { useQuery } from '@tanstack/react-query';
 import { getCommentList } from '@/app/data/commnet';
 import CommentSkeleton from './comment-skeleton';
+import { useRouter } from 'next/navigation';
 
 export default function CommentContainer({
   postId,
@@ -21,7 +22,7 @@ export default function CommentContainer({
   currentUser?: string;
 }) {
   const [page, setPage] = useState(1);
-  const [commentList, setCommentList] = useState<Comment[]>([]);
+  const router = useRouter();
   const { data, isLoading } = useQuery({
     queryKey: [`${postId}:comment`, page],
     queryFn: () =>
@@ -38,6 +39,7 @@ export default function CommentContainer({
 
   const updateList = () => {
     setPage(1);
+    router.refresh();
   };
 
   return (

--- a/app/(detail)/post/[postId]/_components/comment-edit-form.tsx
+++ b/app/(detail)/post/[postId]/_components/comment-edit-form.tsx
@@ -2,7 +2,6 @@ import { editComment } from '@/app/action/comment';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -21,7 +20,6 @@ export default function CommentEditForm({
   commentId,
   page,
 }: Props) {
-  const router = useRouter();
   const formatContent = content.replace(/<br\s*\/?>/gi, '\n');
   const [newContent, setNewContent] = useState(formatContent);
   const queryClient = useQueryClient();

--- a/app/(detail)/post/[postId]/_components/comment-edit-form.tsx
+++ b/app/(detail)/post/[postId]/_components/comment-edit-form.tsx
@@ -1,6 +1,7 @@
 import { editComment } from '@/app/action/comment';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import { toast } from 'sonner';
@@ -10,6 +11,7 @@ interface Props {
   toggleEdit: () => void;
   postId: string;
   commentId: string;
+  page: number;
 }
 
 export default function CommentEditForm({
@@ -17,22 +19,36 @@ export default function CommentEditForm({
   toggleEdit,
   postId,
   commentId,
+  page,
 }: Props) {
   const router = useRouter();
   const formatContent = content.replace(/<br\s*\/?>/gi, '\n');
   const [newContent, setNewContent] = useState(formatContent);
-  const isEditComment = async () => {
-    const result = await editComment({
-      commentId,
-      content: newContent,
-      postId,
-    });
-    if (result.success) {
-      toast.message(result.message);
-      router.refresh();
-      toggleEdit();
-    }
-  };
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const formatNewContent = newContent.replace(/\n/g, '\n\n');
+      return await editComment({
+        commentId,
+        content: formatNewContent,
+        postId,
+      });
+    },
+    onSuccess: (result) => {
+      if (result.success) {
+        toast.success(result.message); // 성공 메시지 표시
+        queryClient.invalidateQueries({
+          queryKey: [`${postId}:comment`, page],
+        }); // 댓글 목록 갱신
+        toggleEdit();
+      } else {
+        toast.error(result.message); // 에러 메시지 표시
+      }
+    },
+    onError: () => {
+      toast.error('댓글 수정에 실패했습니다.'); // 일반적인 에러 메시지 표시
+    },
+  });
 
   return (
     <div className='flex flex-col items-end gap-4'>
@@ -50,7 +66,7 @@ export default function CommentEditForm({
         >
           취소
         </Button>
-        <Button onClick={isEditComment} type='button'>
+        <Button onClick={() => mutation.mutate()} type='button'>
           확인
         </Button>
       </div>

--- a/app/(detail)/user/[userId]/_components/follow-container.tsx
+++ b/app/(detail)/user/[userId]/_components/follow-container.tsx
@@ -9,7 +9,7 @@ export default async function FollowContainer() {
       <h1 className='text-2xl font-bold'>팔로우 목록</h1>
       {!followList || followList.length === 0 ? (
         <ul className='flex flex-col items-center'>
-          <div className='flex items-center justify-center gap-5 border rounded-lg shadow-lg w-1/2 h-52 px-8 py-4 hover:-translate-y-1 transition-transform text-2xl font-semibold'>
+          <div className='bg-white flex items-center justify-center gap-5 rounded-lg shadow-lg w-full md:w-1/2 lg:w-1/2 h-52 px-8 py-4 hover:-translate-y-1 transition-transform text-2xl font-semibold'>
             팔로우한 유저가 없습니다!
           </div>
         </ul>

--- a/app/(detail)/user/[userId]/_components/like-container.tsx
+++ b/app/(detail)/user/[userId]/_components/like-container.tsx
@@ -14,7 +14,7 @@ export default async function LikeContainer() {
           </div>
         </ul>
       ) : (
-        <ul className='grid grid-cols-3 w-full gap-4'>
+        <ul className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 items-center justify-center'>
           {likeList.map((post) => (
             <li key={post.id}>
               <PostCard

--- a/app/(detail)/user/[userId]/_components/like-container.tsx
+++ b/app/(detail)/user/[userId]/_components/like-container.tsx
@@ -9,7 +9,7 @@ export default async function LikeContainer() {
       <h1 className='text-2xl font-bold'>좋아요 목록</h1>
       {!likeList || likeList.length === 0 ? (
         <ul className='flex flex-col items-center'>
-          <div className='flex items-center justify-center gap-5 border rounded-lg shadow-lg w-1/2 h-52 px-8 py-4 hover:-translate-y-1 transition-transform text-2xl font-semibold'>
+          <div className='bg-white flex items-center justify-center gap-5 rounded-lg shadow-lg w-full md:w-1/2 lg:w-1/2 h-52 px-8 py-4 hover:-translate-y-1 transition-transform text-2xl font-semibold'>
             좋아요한 글이 없습니다!
           </div>
         </ul>

--- a/app/_components/post-container.tsx
+++ b/app/_components/post-container.tsx
@@ -12,7 +12,7 @@ export default async function PostContainer({ list, title }: Props) {
       <h1 className='text-2xl font-bold'>{title}</h1>
       {!list || list.length === 0 ? (
         <ul className='flex flex-col items-center'>
-          <div className='flex items-center justify-center gap-5 border rounded-lg shadow-lg w-1/2 h-52 px-8 py-4 hover:-translate-y-1 transition-transform text-2xl font-semibold'>
+          <div className='bg-white flex items-center justify-center gap-5 rounded-lg shadow-lg w-full md:w-1/2 lg:w-1/2 h-52 px-8 py-4 hover:-translate-y-1 transition-transform text-2xl font-semibold'>
             작성한 포스트가 없습니다!
           </div>
         </ul>


### PR DESCRIPTION
댓글은 옵티미스틱 업데이트 적용하면 안되는 내용이라 mutate로 생성 및 삭제시 쿼리 초기화
순서가 바뀌는 이슈로 모든 페이지 쿼리 초기화 적용
쿼리만 다시 받아오면 서버에서 댓글 갯수를 가져오고 있어서 refresh하고 있음 페이지 전체 refresh라서 나중에 클라이언트 렌더링으로 변경필요함
수정시에는 해당 페이지만 쿼리 초기화
