### PR TITLE
feat: 헤딩 태그 스크롤 리스트 추가

### DIFF
--- a/app/(detail)/post/[postId]/_components/post-heading-list.tsx
+++ b/app/(detail)/post/[postId]/_components/post-heading-list.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface Props {
+  content: string;
+}
+
+function Heading({ text }: { text: string }) {
+  const replaceText = text.replace(/#/g, '    ');
+  const headingId = text.replace(/#/g, '').trim();
+  const scrollToElementById = () => {
+    const element = document.getElementById(headingId);
+    if (element) {
+      const elementPosition =
+        element.getBoundingClientRect().top + window.scrollY;
+      const offsetPosition = elementPosition - 100;
+      window.scrollTo({
+        top: offsetPosition,
+        behavior: 'smooth',
+      });
+    }
+  };
+
+  useEffect(() => {}, []);
+
+  return (
+    <div
+      className='cursor-pointer text-[15px] hover:text-[16px] text-gray-500 hover:text-blue-500 h-6'
+      onClick={scrollToElementById}
+    >
+      <p className='whitespace-pre-wrap'>{`${replaceText}`}</p>
+    </div>
+  );
+}
+
+export default function PostHeadingList({ content }: Props) {
+  const headingList = content.match(/^(#{1,3}\s.*)$/gm) || [];
+
+  return (
+    <div className='hidden fixed top-40 left-1/2 translate-x-[420px] h-fit lg:flex'>
+      <ul className='flex flex-col gap-0.5'>
+        {headingList.map((item, index) => (
+          <li key={index}>
+            <Heading text={item} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/(detail)/post/[postId]/page.tsx
+++ b/app/(detail)/post/[postId]/page.tsx
@@ -6,6 +6,7 @@ import { getPostById } from '@/app/data/post';
 import { Metadata } from 'next';
 import { getCommentList } from '@/app/data/commnet';
 import { getSessionUserData } from '@/app/data/user';
+import PostHeadingList from './_components/post-heading-list';
 
 interface Props {
   params: { postId: string };
@@ -53,6 +54,7 @@ export default async function Page({ params }: Props) {
         personalStatus={personalStatus}
         post={post}
       />
+      <PostHeadingList content={post.content} />
     </div>
   );
 }

--- a/components/markdown-editor.tsx
+++ b/components/markdown-editor.tsx
@@ -49,6 +49,21 @@ export default function MarkdownEditor({
             {props.children}
           </Link>
         ),
+        h1: (props) => (
+          <h1 id={String(props.children).replace(/#/g, '').trim()}>
+            {props.children}
+          </h1>
+        ),
+        h2: (props) => (
+          <h1 id={String(props.children).replace(/#/g, '').trim()}>
+            {props.children}
+          </h1>
+        ),
+        h3: (props) => (
+          <h1 id={String(props.children).replace(/#/g, '').trim()}>
+            {props.children}
+          </h1>
+        ),
       }}
     >
       {markdownText}


### PR DESCRIPTION
마크다운에서 `#`으로 작성된 텍스트 추출해서 빈칸으로 변환 후 리스트 만들어줌 
h1,h2,h3 태그에 id값 부여해서 해당 id가진 태그 위치 계산
리스트에서 해당 태그 클릭시 이동