### PR TITLE
포스트 제목 리스트 수정 및 로직 수정

### DIFF
--- a/app/(detail)/post/[postId]/_components/heading.tsx
+++ b/app/(detail)/post/[postId]/_components/heading.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+interface Props {
+  text: string;
+  count: number;
+}
+
+const space = {
+  1: 'pl-3',
+  2: 'pl-7',
+  3: 'pl-12',
+};
+
+export default function Heading({ text, count }: Props) {
+  const replaceText = text.replace(/#/g, '');
+  const headingId = text.replace(/#/g, '').trim();
+  const scrollToElementById = () => {
+    const element = document.getElementById(headingId);
+    if (element) {
+      const elementPosition =
+        element.getBoundingClientRect().top + window.scrollY;
+      const offsetPosition = elementPosition - 100;
+      window.scrollTo({
+        top: offsetPosition,
+        behavior: 'smooth',
+      });
+    }
+  };
+
+  return (
+    <div
+      className={`cursor-pointer text-[15px] text-gray-500 ${
+        space[count as 1 | 2 | 3]
+      } hover:text-blue-500 min-h-6`}
+      onClick={scrollToElementById}
+    >
+      <p className='break-keep'>{`${replaceText}`}</p>
+    </div>
+  );
+}

--- a/app/(detail)/post/[postId]/_components/post-heading-list.tsx
+++ b/app/(detail)/post/[postId]/_components/post-heading-list.tsx
@@ -1,48 +1,22 @@
-'use client';
-
-import { useEffect } from 'react';
+import Heading from './heading';
 
 interface Props {
   content: string;
 }
 
-function Heading({ text }: { text: string }) {
-  const replaceText = text.replace(/#/g, '    ');
-  const headingId = text.replace(/#/g, '').trim();
-  const scrollToElementById = () => {
-    const element = document.getElementById(headingId);
-    if (element) {
-      const elementPosition =
-        element.getBoundingClientRect().top + window.scrollY;
-      const offsetPosition = elementPosition - 100;
-      window.scrollTo({
-        top: offsetPosition,
-        behavior: 'smooth',
-      });
-    }
-  };
-
-  useEffect(() => {}, []);
-
-  return (
-    <div
-      className='cursor-pointer text-[15px] hover:text-[16px] text-gray-500 hover:text-blue-500 h-6'
-      onClick={scrollToElementById}
-    >
-      <p className='whitespace-pre-wrap'>{`${replaceText}`}</p>
-    </div>
-  );
-}
-
 export default function PostHeadingList({ content }: Props) {
   const headingList = content.match(/^(#{1,3}\s.*)$/gm) || [];
+  const countSpace = (heading: string) => {
+    const matches = heading.match(new RegExp('#', 'g'));
+    return matches ? matches.length : 0;
+  };
 
   return (
-    <div className='hidden fixed top-40 left-1/2 translate-x-[420px] h-fit lg:flex'>
+    <div className='hidden fixed top-40 left-1/2 translate-x-[420px] h-fit lg:flex w-60'>
       <ul className='flex flex-col gap-0.5'>
         {headingList.map((item, index) => (
-          <li key={index}>
-            <Heading text={item} />
+          <li key={index} className='w-fit'>
+            <Heading text={item} count={countSpace(item)} />
           </li>
         ))}
       </ul>

--- a/app/action/log.ts
+++ b/app/action/log.ts
@@ -88,14 +88,16 @@ export const addGithubLog = async (
     };
 
   try {
-    const transformLog = log.map((item) => ({
-      user_id: session.id,
-      pr_count: item.count,
-      pr_url: item.url,
-      created_at: item.createdAt,
-    }));
+    const transformLog = log
+      .map((item) => ({
+        user_id: session.id,
+        pr_count: item.count,
+        pr_url: item.url,
+        created_at: item.createdAt,
+      }))
+      .reverse();
 
-    const logDates = transformLog.map((log) => log.created_at).reverse(); // 깃허브 로그 날짜 배열
+    const logDates = transformLog.map((log) => log.created_at); // 깃허브 로그 날짜 배열
 
     const start = logDates[0];
     const end = `${logDates[logDates.length - 1]}T23:59:59Z`;
@@ -106,7 +108,7 @@ export const addGithubLog = async (
       .eq('user_id', session.id)
       .gte('created_at', start)
       .lte('created_at', end)
-      .order('created_at', { ascending: false });
+      .order('created_at', { ascending: true });
 
     if (error) console.error('Error:', error);
 

--- a/app/data/post.ts
+++ b/app/data/post.ts
@@ -85,7 +85,7 @@ export const getMostLikePost = async () => {
   const { data, error } = await supabase
     .from('posts') // posts 테이블에서
     .select('id, title, user_id')
-    .order('like_count', { ascending: true })
+    .order('like_count', { ascending: false })
     .order('createdAt', { ascending: false })
     .limit(3); // 상위 3개 포스트 가져오기
 

--- a/components/markdown-editor.tsx
+++ b/components/markdown-editor.tsx
@@ -55,15 +55,21 @@ export default function MarkdownEditor({
           </h1>
         ),
         h2: (props) => (
-          <h1 id={String(props.children).replace(/#/g, '').trim()}>
+          <h2 id={String(props.children).replace(/#/g, '').trim()}>
             {props.children}
-          </h1>
+          </h2>
         ),
         h3: (props) => (
-          <h1 id={String(props.children).replace(/#/g, '').trim()}>
+          <h3 id={String(props.children).replace(/#/g, '').trim()}>
             {props.children}
-          </h1>
+          </h3>
         ),
+        h4: (props) => (
+          <h4 id={String(props.children).replace(/#/g, '').trim()}>
+            {props.children}
+          </h4>
+        ),
+        p: (props) => <p className='py-3'>{props.children}</p>,
       }}
     >
       {markdownText}

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -314,7 +314,7 @@ export type Database = {
           createdAt?: string;
           id?: string;
           isPublished?: boolean;
-          like_count?: number | null;
+          like_count?: number;
           summation: string;
           tag?: string[] | null;
           thumbnail?: string | null;


### PR DESCRIPTION
제목 리스트 아이템 컴포넌트 분리
제목 리스트가 길어질 경우를 대비해 길이 제한 및 스타일 수정, `#`갯수에 따라 텍스트 앞에 공백 추가에서 padding추가로 변경
로그 업데이트 로직 수정
포스트 좋아요순 순서가 반대로 되어있어서 수정, like_count값 default 0으로 수정
마크다운 변환 로직 스타일 수정

