### PR TITLE
업데이트 로그 필터링 수정 및 업데이트 요청 수정

### DIFF
--- a/app/(detail)/user/[userId]/_components/calendar-single-day.tsx
+++ b/app/(detail)/user/[userId]/_components/calendar-single-day.tsx
@@ -33,7 +33,7 @@ export default function CalendarSingleDay({ day, log, containerRef }: Props) {
     if (50 >= rate && rate !== 0) {
       return 'bg-blue-100 border-blue-100';
     }
-    if (rate >= 50 && rate < 50) {
+    if (rate >= 50 && rate < 100) {
       return 'bg-blue-300 border-blue-300';
     }
     if (rate >= 100) {

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -314,7 +314,7 @@ export type Database = {
           createdAt?: string;
           id?: string;
           isPublished?: boolean;
-          like_count?: number;
+          like_count?: number | null;
           summation: string;
           tag?: string[] | null;
           thumbnail?: string | null;


### PR DESCRIPTION
이미 커밋을 연동해서 적용해놨다고 가정했을때 등록한 날 이후의 커밋을 업데이트하면 모든 로그가 업데이트 대상으로 묶이는 문제가 발생
-> 등록된 로그의 count나 url이 깃헙 로그와 다른 경우에만 업데이트 되도록 설정
업데이트 로직에 userId만 특정해서 업데이트 요청을해서 전부 같은 데이터로 업데이트되는 문제 발생
-> 기존 db의 로그의 id를 추가해줘서 해당 로그만 업데이트하도록 수정