### PR TITLE
fix: 옵저버에 스크롤 방향에 따른 액션 구분

### DIFF
--- a/app/(detail)/post/[postId]/_components/post-heading-list.tsx
+++ b/app/(detail)/post/[postId]/_components/post-heading-list.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable prefer-const */
 'use client';
 
 import { useEffect, useState } from 'react';
@@ -8,14 +9,17 @@ interface Props {
 }
 
 export default function PostHeadingList({ content }: Props) {
-  const [activeHeading, setActiveHeading] = useState('');
+  const [activeHeading, setActiveHeading] = useState(0);
   const headingList = content.match(/^(#{1,3}\s.*)$/gm) || [];
+  const firstHeading = headingList[0]
+    ? headingList[0].replace(/#/g, '').trim()
+    : '';
 
   useEffect(() => {
-    const navElement = document.querySelector('nav');
     const headings = document.querySelectorAll('h1, h2, h3');
     const observedSet = new Set(); // 감지된 요소만 저장하는 데이터
-    if (!navElement || !headings) return;
+    let lastScrollTop = 0; // 이전 스크롤 위치
+    if (!headings) return;
 
     const observerCallback = (entries: IntersectionObserverEntry[]) => {
       entries.forEach((entry) => {
@@ -23,9 +27,20 @@ export default function PostHeadingList({ content }: Props) {
           observedSet.add(entry.target);
           return;
         }
-        if (!entry.isIntersecting) {
-          setActiveHeading(() => entry.target.id);
+        const currentScrollTop =
+          window.scrollY || document.documentElement.scrollTop;
+        if (currentScrollTop > lastScrollTop) {
+          if (!entry.isIntersecting) {
+            if (entry.target.id === firstHeading) return;
+            setActiveHeading((prev) => prev + 1);
+          }
+        } else if (currentScrollTop < lastScrollTop) {
+          if (entry.isIntersecting) {
+            if (entry.target.id === firstHeading) return;
+            setActiveHeading((prev) => prev - 1);
+          }
         }
+        lastScrollTop = currentScrollTop <= 0 ? 0 : currentScrollTop;
       });
     };
 
@@ -51,7 +66,7 @@ export default function PostHeadingList({ content }: Props) {
     return () => {
       headings.forEach((heading) => observer.unobserve(heading));
     };
-  }, []);
+  }, [firstHeading]);
 
   return (
     <div className='hidden fixed top-40 left-1/2 translate-x-[420px] h-fit lg:flex w-60'>
@@ -62,7 +77,7 @@ export default function PostHeadingList({ content }: Props) {
             <li key={index} className='w-fit'>
               <Heading
                 text={item}
-                isActive={activeHeading === headingId}
+                isActive={activeHeading === index}
                 id={headingId}
               />
             </li>


### PR DESCRIPTION
스크롤 아래로 동작시 활성화된 영역표시 정상 동작함
스크롤 위로 동작시 상단에 진입한 영역 표시가 안되고 현재 영역 이전 영역이 활성화가 되는 문제가 있음
태그 id와 옵저버에 감지된 태그 id로 구분하는 로직에서 인덱스를 조절해주는 로직으로 수정
스크롤 아래로 동작시 현재 활성화된 heading 인덱스 + 1,
스르콜 위로 동작시 현재 활성화된 heading 인덱스 - 1
(첫번째 heading태그 제외)