### PR TITLE
giscus 추가

### DIFF
--- a/app/(detail)/post/[postId]/page.tsx
+++ b/app/(detail)/post/[postId]/page.tsx
@@ -6,6 +6,7 @@ import { getPostById } from '@/app/data/post';
 import { Metadata } from 'next';
 import { getSessionUserData } from '@/app/data/user';
 import PostHeadingList from './_components/post-heading-list';
+import GiscusComment from '@/components/giscus';
 
 interface Props {
   params: { postId: string };
@@ -40,6 +41,7 @@ export default async function Page({ params }: Props) {
         currentUser={session?.id}
         limit={5}
       />
+      <GiscusComment />
       <FloatingContainer
         totalLike={post.like_count ? post.like_count : 0}
         createrId={post.user_id}

--- a/components/giscus.tsx
+++ b/components/giscus.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useTheme } from 'next-themes';
+
+export default function Giscus() {
+  const ref = useRef<HTMLDivElement>(null);
+  const { resolvedTheme } = useTheme();
+
+  // https://github.com/giscus/giscus/tree/main/styles/themes
+  const theme = resolvedTheme === 'dark' ? 'dark' : 'light';
+
+  useEffect(() => {
+    if (!ref.current || ref.current.hasChildNodes()) return;
+
+    const scriptElem = document.createElement('script');
+    scriptElem.src = 'https://giscus.app/client.js';
+    scriptElem.async = true;
+    scriptElem.crossOrigin = 'anonymous';
+
+    scriptElem.setAttribute('data-repo', 'sj0724/blog-comments');
+    scriptElem.setAttribute('data-repo-id', 'R_kgDONVjA1g');
+    scriptElem.setAttribute('data-category', 'General');
+    scriptElem.setAttribute('data-category-id', 'DIC_kwDONVjA1s4Ckpkn');
+    scriptElem.setAttribute('data-mapping', 'pathname');
+    scriptElem.setAttribute('data-strict', '0');
+    scriptElem.setAttribute('data-reactions-enabled', '0');
+    scriptElem.setAttribute('data-emit-metadata', '0');
+    scriptElem.setAttribute('data-input-position', 'top');
+    scriptElem.setAttribute('data-theme', theme);
+    scriptElem.setAttribute('data-lang', 'ko');
+
+    ref.current.appendChild(scriptElem);
+  }, [theme]);
+
+  // https://github.com/giscus/giscus/blob/main/ADVANCED-USAGE.md#isetconfigmessage
+  useEffect(() => {
+    const iframe = document.querySelector<HTMLIFrameElement>(
+      'iframe.giscus-frame'
+    );
+    iframe?.contentWindow?.postMessage(
+      { giscus: { setConfig: { theme } } },
+      'https://giscus.app'
+    );
+  }, [theme]);
+
+  // useEffect(() => {
+  //   const handleGiscusComment = (event: any) => {
+  //     if (event.origin !== 'https://giscus.app') return;
+  //     if (!(typeof event.data === 'object' && event.data.giscus)) return;
+  //     const giscusData = event.data.giscus;
+  //     if ('discussion' in giscusData) {
+  //       const metadataMessage: IMetadataMessage = giscusData;
+  //       console.log(metadataMessage.discussion);
+  //       console.log(metadataMessage.viewer);
+  //     }
+  //   };
+
+  //   window.addEventListener('message', handleGiscusComment);
+
+  //   return () => {
+  //     window.removeEventListener('message', handleGiscusComment);
+  //   };
+  // }, []);
+
+  return <section ref={ref} className='w-full' />;
+}


### PR DESCRIPTION
현재 댓글 기능 대댓글이나 리액션 추가가 안됨
-> 댓글 기능 고도화를 위해 추가 db 테이블 생성보다는 다른 수단을 선택하는게 맞다고 판단했음

giscus 채택 이유
- 대댓글 및 리액션 가능
- 라이브러리가 아닌 스크립트 추가로 라이브러리 의존도 없음
- 깃허브 계정과 연동해서 댓글을 사용하기 때문에 블로그 취지에도 맞음
